### PR TITLE
Basic scanner implementation

### DIFF
--- a/matrix_content_scanner/mcs.py
+++ b/matrix_content_scanner/mcs.py
@@ -26,6 +26,7 @@ from matrix_content_scanner import logutils
 from matrix_content_scanner.config import MatrixContentScannerConfig
 from matrix_content_scanner.httpserver import HTTPServer
 from matrix_content_scanner.scanner.file_downloader import FileDownloader
+from matrix_content_scanner.scanner.scanner import Scanner
 from matrix_content_scanner.utils.errors import ConfigError
 
 logger = logging.getLogger(__name__)
@@ -52,6 +53,10 @@ class MatrixContentScanner:
     @cached_property
     def file_downloader(self) -> FileDownloader:
         return FileDownloader(self)
+
+    @cached_property
+    def scanner(self) -> Scanner:
+        return Scanner(self)
 
     def start(self) -> None:
         """Start the HTTP server and start the reactor."""

--- a/matrix_content_scanner/scanner/scanner.py
+++ b/matrix_content_scanner/scanner/scanner.py
@@ -162,7 +162,9 @@ class Scanner:
         # to make sure there isn't any '..' etc in the full path, to make sure we don't
         # try to write outside the directory.
         full_path = self._store_directory.joinpath(media_path).resolve()
-        if not full_path.is_relative_to(self._store_directory):
+        if not f"{full_path}{os.sep}".startswith(str(self._store_directory)):
+            # Ideally we'd use full_path.is_relative_to but that's only available from
+            # Python 3.9 and we want to support 3.8.
             raise FileDirtyError("Malformed media ID")
 
         logger.info("Writing file to %s", full_path)

--- a/matrix_content_scanner/scanner/scanner.py
+++ b/matrix_content_scanner/scanner/scanner.py
@@ -11,8 +11,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-import hashlib
-import json
 import logging
 import os.path
 import subprocess
@@ -21,7 +19,6 @@ from typing import TYPE_CHECKING, Dict, List, Optional
 import attr
 from mautrix.crypto.attachments import decrypt_attachment
 from mautrix.errors import DecryptionError
-from mautrix.util import magic
 
 from matrix_content_scanner.utils.constants import ErrCode
 from matrix_content_scanner.utils.errors import ContentScannerRestError, FileDirtyError

--- a/matrix_content_scanner/scanner/scanner.py
+++ b/matrix_content_scanner/scanner/scanner.py
@@ -157,14 +157,14 @@ class Scanner:
             FileDirtyError if the media path is malformed in a way that would cause the
                 file to be written outside the configured directory.
         """
-        # Figure out the full absolute path for this file. Given _store_directory is
-        # already an absolute path, just joining paths is likely good enough, but we want
-        # to make sure there isn't any '..' etc in the full path, to make sure we don't
-        # try to write outside the directory.
+        # Figure out the full absolute path for this file.
         full_path = self._store_directory.joinpath(media_path).resolve()
-        if not f"{full_path}{os.sep}".startswith(str(self._store_directory)):
-            # Ideally we'd use full_path.is_relative_to but that's only available from
-            # Python 3.9 and we want to support 3.8.
+        try:
+            # Check if the full path is a sub-path to the store's path, to make sure
+            # there isn't any '..' etc in the full path, which would cause us to try
+            # writing outside the store's directory.
+            full_path.relative_to(self._store_directory)
+        except ValueError:
             raise FileDirtyError("Malformed media ID")
 
         logger.info("Writing file to %s", full_path)

--- a/matrix_content_scanner/scanner/scanner.py
+++ b/matrix_content_scanner/scanner/scanner.py
@@ -1,0 +1,193 @@
+#  Copyright 2022 The Matrix.org Foundation C.I.C.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import hashlib
+import json
+import logging
+import os.path
+import subprocess
+from typing import TYPE_CHECKING, Dict, List, Optional
+
+import attr
+from mautrix.crypto.attachments import decrypt_attachment
+from mautrix.errors import DecryptionError
+from mautrix.util import magic
+
+from matrix_content_scanner.utils.constants import ErrCode
+from matrix_content_scanner.utils.errors import ContentScannerRestError, FileDirtyError
+from matrix_content_scanner.utils.types import JsonDict, MediaDescription
+
+if TYPE_CHECKING:
+    from matrix_content_scanner.mcs import MatrixContentScanner
+
+logger = logging.getLogger(__name__)
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class CacheEntry:
+    result: bool
+    media: Optional[MediaDescription] = None
+    info: Optional[str] = None
+
+
+class Scanner:
+    def __init__(self, mcs: "MatrixContentScanner"):
+        self._file_downloader = mcs.file_downloader
+        self._script = mcs.config.scan.script
+        self._removal_command = mcs.config.scan.removal_command
+        self._store_directory = os.path.abspath(mcs.config.scan.temp_directory)
+
+    async def scan_file(
+        self,
+        media_path: str,
+        metadata: Optional[JsonDict] = None,
+        thumbnail_params: Optional[Dict[str, List[str]]] = None,
+    ) -> MediaDescription:
+        """Download and scan the given media.
+
+        Unless the scan fails with one of the codes listed in `do_not_cache_exit_codes`,
+        also cache the result.
+
+        If the file already has an entry in the result cache, return this value without
+        downloading the file again.
+
+        Args:
+            media_path: The `server_name/media_id` path for the media.
+            metadata: The metadata attached to the file (e.g. decryption key), or None if
+                the file isn't encrypted.
+            thumbnail_params: If present, then we want to request and scan a thumbnail
+                generated with the provided parameters instead of the full media.
+
+        Returns:
+            A description of the media.
+
+        Raises:
+            ContentScannerRestError if the file could not be downloaded.
+            FileDirtyError if the result of the scan said that the file is dirty, or if
+                the media path is malformed.
+        """
+        # Check if the media path is valid and only contains one slash (otherwise we'll
+        # have issues parsing it further down the line).
+        if media_path.count("/") != 1:
+            raise FileDirtyError("Malformed media ID")
+
+        # Download the file, and decrypt it if necessary.
+        media = await self._file_downloader.download_file(
+            media_path=media_path,
+            thumbnail_params=thumbnail_params,
+        )
+
+        media_content = media.content
+        if metadata is not None:
+            # If the file is encrypted, we need to decrypt it before we can scan it.
+            media_content = self._decrypt_file(media_content, metadata)
+
+        # Write the file to disk.
+        file_path = self._write_file_to_disk(media_path, media_content)
+
+        # Scan the file and see if the result is positive or negative.
+        exit_code = self._run_scan(file_path)
+        result = exit_code == 0
+
+        # Delete the file now that we've scanned it.
+        logger.info("Scan has finished, removing file")
+        removal_command_parts = self._removal_command.split()
+        removal_command_parts.append(file_path)
+        subprocess.run(removal_command_parts)
+
+        # Raise an error if the result isn't clean.
+        if result is False:
+            raise FileDirtyError()
+
+        return media
+
+    def _decrypt_file(self, body: bytes, metadata: JsonDict) -> bytes:
+        """Extract decryption information from the file's metadata and decrypt it.
+
+        Args:
+            body: The encrypted body of the file.
+            metadata: The part of the request that includes decryption information.
+
+        Returns:
+            The decrypted content of the file.
+
+        Raises:
+            ContentScannerRestError(400) if the decryption failed.
+        """
+        logger.info("File is encrypted, decrypting")
+
+        # At this point the schema should have been validated so we can pull these values
+        # out safely.
+        key = metadata["file"]["key"]["k"]
+        hash = metadata["file"]["hashes"]["sha256"]
+        iv = metadata["file"]["iv"]
+
+        # Decrypt the file.
+        try:
+            return decrypt_attachment(body, key, hash, iv)
+        except DecryptionError as e:
+            raise ContentScannerRestError(
+                http_status=400,
+                reason=ErrCode.FAILED_TO_DECRYPT,
+                info=e.message,
+            )
+
+    def _write_file_to_disk(self, media_path: str, body: bytes) -> str:
+        """Writes the given content to disk. The final file name will be a concatenation
+        of `temp_directory` and the media's `server_name/media_id` path.
+
+        Args:
+            media_path: The `server_name/media_id` path of the media we're processing.
+            body: The bytes to write to disk.
+
+        Returns:
+            The full path to the newly written file.
+
+        Raises:
+            FileDirtyError if the media path is malformed in a way that would cause the
+                file to be written outside the configured directory.
+        """
+        # Figure out the full absolute path for this file. Given _store_directory is
+        # already an absolute path using os.path.join is likely good enough, but we want
+        # to make sure there isn't any '..' etc in the full path, to make sure we don't
+        # try to write outside the directory.
+        full_path = os.path.abspath(os.path.join(self._store_directory, media_path))
+        if not full_path.startswith(self._store_directory):
+            raise FileDirtyError("Malformed media ID")
+
+        logger.info("Writing file to %s", full_path)
+
+        # Create any directory we need.
+        os.makedirs(os.path.dirname(full_path), exist_ok=True)
+
+        with open(full_path, "wb") as fp:
+            fp.write(body)
+
+        return full_path
+
+    def _run_scan(self, file_name: str) -> int:
+        """Runs the scan script, passing it the given file name.
+
+        Args:
+            file_name: Name of the file to scan.
+
+        Returns:
+            The exit code the script returned.
+        """
+        try:
+            subprocess.run([self._script, file_name], check=True)
+            logger.info("Scan succeeded")
+            return 0
+        except subprocess.CalledProcessError as e:
+            logger.info("Scan failed with exit code %d: %s", e.returncode, e.stderr)
+            return e.returncode

--- a/matrix_content_scanner/utils/errors.py
+++ b/matrix_content_scanner/utils/errors.py
@@ -24,6 +24,17 @@ class ContentScannerRestError(Exception):
         self.info = info
 
 
+class FileDirtyError(ContentScannerRestError):
+    """An error indicating that the file being scanned is dirty."""
+
+    def __init__(self, info: str = "***VIRUS DETECTED***") -> None:
+        super(FileDirtyError, self).__init__(
+            http_status=403,
+            reason=ErrCode.NOT_CLEAN,
+            info=info,
+        )
+
+
 class ConfigError(Exception):
     """An error indicating an issue with the configuration file."""
 

--- a/tests/scanner/test_scanner.py
+++ b/tests/scanner/test_scanner.py
@@ -1,0 +1,120 @@
+#  Copyright 2022 The Matrix.org Foundation C.I.C.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import copy
+from typing import Dict, List, Optional
+from unittest.mock import Mock
+
+import aiounittest
+from twisted.web.http_headers import Headers
+
+from matrix_content_scanner.utils.constants import ErrCode
+from matrix_content_scanner.utils.errors import ContentScannerRestError, FileDirtyError
+from matrix_content_scanner.utils.types import MediaDescription
+from tests.testutils import (
+    ENCRYPTED_FILE_METADATA,
+    MEDIA_PATH,
+    SMALL_PNG,
+    SMALL_PNG_ENCRYPTED,
+    get_content_scanner,
+)
+
+
+class ScannerTestCase(aiounittest.AsyncTestCase):
+    def setUp(self) -> None:
+        self.downloader_res = MediaDescription(
+            content_type="image/png",
+            content=SMALL_PNG,
+            response_headers=Headers(),
+        )
+
+        async def download_file(
+            media_path: str,
+            thumbnail_params: Optional[Dict[str, List[str]]] = None,
+        ) -> MediaDescription:
+            """Mock for the file downloader's `download_file` method."""
+            return self.downloader_res
+
+        self.downloader_mock = Mock(side_effect=download_file)
+
+        # Mock download_file so we don't actually try to download files.
+        mcs = get_content_scanner()
+        mcs.file_downloader.download_file = self.downloader_mock  # type: ignore[assignment]
+        self.scanner = mcs.scanner
+
+    async def test_scan(self) -> None:
+        """Tests that we can scan files and that the scanner returns the media scanned if
+        the scan was successful.
+        """
+        media = await self.scanner.scan_file(MEDIA_PATH)
+        self.assertEqual(media.content, SMALL_PNG)
+
+    async def test_scan_dirty(self) -> None:
+        """Tests that the scanner raises a FileDirtyError if the scan fails."""
+        self.scanner._script = "false"
+        with self.assertRaises(FileDirtyError):
+            await self.scanner.scan_file(MEDIA_PATH)
+
+    async def test_encrypted_file(self) -> None:
+        """Tests that the scanner can decrypt and scan encrypted files, and that if the
+        scan is successful it returns the encrypted file and not the decrypted version.
+        """
+        self._setup_encrypted()
+
+        media = await self.scanner.scan_file(MEDIA_PATH, ENCRYPTED_FILE_METADATA)
+        self.assertEqual(media.content, SMALL_PNG_ENCRYPTED)
+
+    async def test_different_encryption_key(self) -> None:
+        """Tests that if some of the file's metadata changed, we don't match against the
+        cache and we download the file again.
+
+        Also tests that the scanner fails in the correct way if it can't decrypt a file.
+        """
+        self._setup_encrypted()
+
+        # Scan the file and check that the downloader was called.
+        await self.scanner.scan_file(MEDIA_PATH, ENCRYPTED_FILE_METADATA)
+        self.assertEqual(self.downloader_mock.call_count, 1)
+
+        # Copy the file metadata and change the key.
+        modified_metadata = copy.deepcopy(ENCRYPTED_FILE_METADATA)
+        modified_metadata["file"]["key"]["k"] = "somethingelse"
+
+        # This causes the scanner to not be able to decrypt the file.
+        with self.assertRaises(ContentScannerRestError) as cm:
+            await self.scanner.scan_file(MEDIA_PATH, modified_metadata)
+
+        self.assertEqual(cm.exception.http_status, 400)
+        self.assertEqual(cm.exception.reason, ErrCode.FAILED_TO_DECRYPT)
+
+        # But it also causes it to be downloaded again because its metadata have changed.
+        self.assertEqual(self.downloader_mock.call_count, 2)
+
+    async def test_outside_temp_dir(self) -> None:
+        """Tests that a scan is failed if the media path is formed in a way that would
+        cause the scanner to write outside of the configured directory.
+        """
+        with self.assertRaises(FileDirtyError):
+            await self.scanner.scan_file("../bar")
+
+    async def test_invalid_media_path(self) -> None:
+        """Tests that a scan fails if the media path is invalid."""
+        with self.assertRaises(FileDirtyError):
+            await self.scanner.scan_file(MEDIA_PATH + "/baz")
+
+    def _setup_encrypted(self) -> None:
+        """Sets up class properties to make the downloader return an encrypted file
+        instead of a plain text one.
+        """
+        self.downloader_res.content_type = "application/octet-stream"
+        self.downloader_res.content = SMALL_PNG_ENCRYPTED

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -11,6 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+import os
 from binascii import unhexlify
 from typing import Optional
 
@@ -91,6 +92,10 @@ def get_content_scanner(config: Optional[JsonDict] = None) -> MatrixContentScann
     Args:
         config: The optional provided config.
     """
+    # Create the temporary directory that we'll use so the scanner doesn't complain about
+    # it not existing.
+    os.makedirs(os.path.abspath("temp"), exist_ok=True)
+
     # We define the default configuration here rather than as a constant outside of a
     # function because otherwise a test that sets its own config would have side effects
     # on the config used for other tests.


### PR DESCRIPTION
This PR implements the `Scanner` class from https://github.com/matrix-org/matrix-content-scanner-python-wip, without:

* result caching
* checking of MIME types against the allow list in the config

These will be the subject of separate PRs in order to minimise the diff of this one.