### PR TITLE
Cache scan results

### DIFF
--- a/matrix_content_scanner/scanner/scanner.py
+++ b/matrix_content_scanner/scanner/scanner.py
@@ -106,6 +106,10 @@ class Scanner:
         # Check if the media path is valid and only contains one slash (otherwise we'll
         # have issues parsing it further down the line).
         if media_path.count("/") != 1:
+            self._result_cache[cache_key] = CacheEntry(
+                result=False,
+                info="Malformed media ID",
+            )
             raise FileDirtyError("Malformed media ID")
 
         # Download the file, and decrypt it if necessary.


### PR DESCRIPTION
Builds on top of https://github.com/matrix-org/matrix-content-scanner-python/pull/17 to cache results and contents of files in a very basic in-memory cache so we don't spend our time fetching media from the homeserver.