### PR TITLE
Cache scan results

### DIFF
--- a/matrix_content_scanner/config.py
+++ b/matrix_content_scanner/config.py
@@ -14,6 +14,7 @@
 from typing import Any, Callable, Dict, List, Optional, Union
 
 import attr
+import humanfriendly
 from jsonschema import ValidationError, validate
 
 from matrix_content_scanner.utils.errors import ConfigError
@@ -132,7 +133,33 @@ class MatrixContentScannerConfig:
         self.result_cache = ResultCacheConfig(**(config_dict.get("result_cache") or {}))
 
 
-def parse_user_value(
+def parse_duration(duration: Optional[Union[str, float]]) -> Optional[float]:
+    """Parse a time duration into a float representing an amount of second. If the given
+    value is None, or already a float, returns it as is.
+
+    Args:
+        duration: The duration to parse.
+
+    Returns:
+        The number of seconds in the given duration.
+    """
+    return _parse_user_value(duration, humanfriendly.parse_timespan)
+
+
+def parse_size(size: Optional[Union[str, float]]) -> Optional[float]:
+    """Parse a file size into a float representing the number of bytes for that size. If
+    the given value is None, or already a float, returns it as is.
+
+    Args:
+        size: The size to parse.
+
+    Returns:
+        The number of bytes represented by the given size.
+    """
+    return _parse_user_value(size, humanfriendly.parse_size)
+
+
+def _parse_user_value(
     v: Optional[Union[str, float]], parser: Callable[[str], float]
 ) -> Optional[float]:
     """Parse a given user-defined string value (such as durations or sizes) into a float.
@@ -152,6 +179,6 @@ def parse_user_value(
         return None
 
     if isinstance(v, float):
-        return float(v)
+        return v
 
     return parser(v)

--- a/matrix_content_scanner/config.sample.yaml
+++ b/matrix_content_scanner/config.sample.yaml
@@ -21,7 +21,7 @@ scan:
     # Optional, defaults to allowing all MIME types.
     allowed_mimetypes: ["image/jpeg"]
 
-# Configuration of the cache scan results will be stored in.
+# Configuration of scan result caching.
 #
 # Results are stored in a time-based LRU (least recently used) cache to avoid having to
 # download and scan a file twice. There is a unique entry in this cache for each set of

--- a/matrix_content_scanner/config.sample.yaml
+++ b/matrix_content_scanner/config.sample.yaml
@@ -26,7 +26,7 @@ scan:
 # Results are stored in a time-based LRU (least recently used) cache to avoid having to
 # download and scan a file twice. There is a unique entry in this cache for each set of
 # media path (i.e. the "server_name/media_id" identifier for the media), thumbnailing
-# parameters and encryption metadata. This means that, for example, that the result for
+# parameters and encryption metadata. This means that, for example, the result for
 # the scan of the media "example.com/abc" and the result for the scan of the  *thumbnail*
 # of "example.com/abc" will be stored in two separate entries.
 #

--- a/matrix_content_scanner/config.sample.yaml
+++ b/matrix_content_scanner/config.sample.yaml
@@ -8,10 +8,10 @@
 #  * d, day, days
 #  * w, week, weeks
 #  * y, year, years
+# If no unit is given, "seconds" are implied.
 #
 # Examples of supported size units can be found here: https://humanfriendly.readthedocs.io/en/latest/api.html#humanfriendly.parse_size
-# Size units use a decimal base, which means that 1KB is parsed as 1000 bytes. Using
-# binary units is possible, however, e.g. 1KiB is parsed as 1024 bytes.
+# Size units use a decimal base, so 1KB means 1000 bytes, while 1KiB means 1024 bytes.
 
 # Configuration for hosting the HTTP(S) API.
 web:
@@ -24,13 +24,16 @@ scan:
     # downloaded file as its only argument, e.g. "./example.sh /temp/foo.bar/my_file".
     # Required.
     script: "./example.sh"
+
     # Directory in which to download files for scanning. Each file downloaded is removed
     # after the scan has completed.
     # Required.
     temp_directory: "/tmp"
+
     # Command to run to remove files from disk once they have been scanned.
     # Optional, defaults to "rm".
     removal_command: "srm"
+
     # List of allowed MIME types. If a file has a MIME type that's not in this list, its
     # scan is considered failed.
     # Optional, defaults to allowing all MIME types.
@@ -38,12 +41,12 @@ scan:
 
 # Configuration of scan result caching.
 #
-# Results are stored in a time-based LRU (least recently used) cache to avoid having to
-# download and scan a file twice. There is a unique entry in this cache for each set of
-# media path (i.e. the "server_name/media_id" identifier for the media), thumbnailing
-# parameters and encryption metadata. This means that, for example, the result for
-# the scan of the media "example.com/abc" and the result for the scan of the  *thumbnail*
-# of "example.com/abc" will be stored in two separate entries.
+# Results are stored in a cache to avoid having to download and scan a file twice. There
+# is a unique entry in this cache for each set of media path (i.e. the
+# "server_name/media_id" identifier for the media), thumbnailing parameters and
+# encryption metadata. This means that, for example, the result for the scan of the media
+# "example.com/abc" and the result for the scan of the  *thumbnail* of "example.com/abc"
+# will be stored in two separate entries.
 #
 # Each entry in the cache includes the result of the scan as well as a copy of the media
 # that was scanned. If the media fails the scan, however, or is larger than the configured
@@ -54,12 +57,17 @@ result_cache:
     # Optional, defaults to an empty list (i.e. results are cached regardless of the
     # script's exit code).
     exit_codes_to_ignore: [1, 2]
-    # Maximum number of results that can be stored in the cache.
+
+    # Maximum number of results that can be stored in the cache. If more files are
+    # scanned before existing items reach their TTL, the least-recently accessed will be
+    # evicted.
     # Optional, defaults to 1024.
     max_size: 2048
+
     # The maximum amount of time an entry will stay in the cache before being evicted.
     # Optional, defaults to 1 week.
     ttl: "1d"
+
     # The maximum cachable file size. If a file is bigger than this size, a copy of it
     # will be not be cached even if the scan succeeds. If the file is requested again, it
     # is downloaded again from the homeserver, but is not written to disk or scanned.
@@ -80,9 +88,11 @@ download:
     # to use.
     # Optional, defaults to downloading files directly from their respective homeservers.
     base_homeserver_url: "https://matrix.org"
+
     # HTTP(S) proxy to use when sending requests.
     # Optional, defaults to no proxy.
     proxy: "http://10.0.0.1:3128"
+
     # Headers to send in outgoing requests.
     # Optional, defaults to no additional headers.
     additional_headers:
@@ -93,6 +103,7 @@ crypto:
     # The path to the Olm pickle file.
     # Required.
     pickle_path: "./pickle"
+
     # The key to the pickle.
     # Required.
     pickle_key: "this_is_a_secret"

--- a/matrix_content_scanner/config.sample.yaml
+++ b/matrix_content_scanner/config.sample.yaml
@@ -13,11 +13,6 @@ scan:
     # after the scan has completed.
     # Required.
     temp_directory: "/tmp"
-    # List of exit codes from the scanning script that shouldn't cause the result of the
-    # scan to be cached in memory for future requests.
-    # Optional, defaults to an empty list (i.e. results are cached regardless of the
-    # script's exit code).
-    do_not_cache_exit_codes: [1, 2]
     # Command to run to remove files from disk once they have been scanned.
     # Optional, defaults to "rm".
     removal_command: "srm"
@@ -25,6 +20,38 @@ scan:
     # scan is considered failed.
     # Optional, defaults to allowing all MIME types.
     allowed_mimetypes: ["image/jpeg"]
+
+# Configuration of the cache scan results will be stored in.
+#
+# Results are stored in a time-based LRU (least recently used) cache to avoid having to
+# download and scan a file twice. There is a unique entry in this cache for each set of
+# media path (i.e. the "server_name/media_id" identifier for the media), thumbnailing
+# parameters and encryption metadata. This means that, for example, that the result for
+# the scan of the media "example.com/abc" and the result for the scan of the  *thumbnail*
+# of "example.com/abc" will be stored in two separate entries.
+#
+# Each entry in the cache includes the result of the scan as well as a copy of the media
+# that was scanned. If the media fails the scan, however, or is larger than the configured
+# maximum size (if set), no copy of the media is stored in the result cache.
+result_cache:
+    # List of exit codes from the scanning script that shouldn't cause the result of the
+    # scan to be cached for future requests.
+    # Optional, defaults to an empty list (i.e. results are cached regardless of the
+    # script's exit code).
+    exit_codes_to_ignore: [1, 2]
+    # Maximum number of results that can be stored in the cache.
+    # Optional, defaults to 1024.
+    max_size: 2048
+    # The maximum amount of time an entry will stay in the cache before being evicted.
+    # The list of supported time units can be found here: https://humanfriendly.readthedocs.io/en/latest/api.html#humanfriendly.parse_timespan
+    # Optional, defaults to 1 week.
+    ttl: "1d"
+    # The maximum cachable file size. If a file is bigger than this size, a copy of it
+    # will be not be cached even if the scan succeeds. If the file is requested again, it
+    # is downloaded again from the homeserver, but is not written to disk or scanned.
+    # Optional, defaults to no maximum size.
+    max_file_size: "100MB"
+
 
 # Configuration for downloading files.
 # When downloading files directly from their respective homeservers (which is the default

--- a/matrix_content_scanner/config.sample.yaml
+++ b/matrix_content_scanner/config.sample.yaml
@@ -1,3 +1,18 @@
+# Configuration file template for the Matrix Content Scanner.
+#
+# Supported time units:
+#  * ms, millisecond, milliseconds
+#  * s, sec, secs, second, seconds
+#  * m, min, mins, minute, minutes
+#  * h, hour, hours
+#  * d, day, days
+#  * w, week, weeks
+#  * y, year, years
+#
+# Examples of supported size units can be found here: https://humanfriendly.readthedocs.io/en/latest/api.html#humanfriendly.parse_size
+# Size units use a decimal base, which means that 1KB is parsed as 1000 bytes. Using
+# binary units is possible, however, e.g. 1KiB is parsed as 1024 bytes.
+
 # Configuration for hosting the HTTP(S) API.
 web:
     host: 127.0.0.1
@@ -43,7 +58,6 @@ result_cache:
     # Optional, defaults to 1024.
     max_size: 2048
     # The maximum amount of time an entry will stay in the cache before being evicted.
-    # The list of supported time units can be found here: https://humanfriendly.readthedocs.io/en/latest/api.html#humanfriendly.parse_timespan
     # Optional, defaults to 1 week.
     ttl: "1d"
     # The maximum cachable file size. If a file is bigger than this size, a copy of it

--- a/matrix_content_scanner/scanner/scanner.py
+++ b/matrix_content_scanner/scanner/scanner.py
@@ -106,6 +106,10 @@ class Scanner:
         # Check if the media path is valid and only contains one slash (otherwise we'll
         # have issues parsing it further down the line).
         if media_path.count("/") != 1:
+            self._result_cache[cache_key] = CacheEntry(
+                result=False,
+                info="Malformed media ID",
+            )
             raise FileDirtyError("Malformed media ID")
 
         # Download the file, and decrypt it if necessary.

--- a/matrix_content_scanner/scanner/scanner.py
+++ b/matrix_content_scanner/scanner/scanner.py
@@ -147,7 +147,7 @@ class Scanner:
             # Compare the media's hash to ensure the server hasn't changed the file since
             # the last scan. If it has changed, shout about it in the logs, discard the
             # cache entry and scan it again.
-            media_hash = hashlib.sha256(media.content)
+            media_hash = hashlib.sha256(media.content).digest()
             if media_hash == cache_entry.media_hash:
                 return media
 
@@ -199,7 +199,7 @@ class Scanner:
 
             # Hash the media, that way if we need to re-download the file we can make sure
             # it's the right one.
-            media_hash = hashlib.sha256(media.content)
+            media_hash = hashlib.sha256(media.content).digest()
 
             self._result_cache[cache_key] = CacheEntry(
                 result=True,

--- a/matrix_content_scanner/utils/errors.py
+++ b/matrix_content_scanner/utils/errors.py
@@ -34,6 +34,12 @@ class FileDirtyError(ContentScannerRestError):
         info: Optional[str] = "***VIRUS DETECTED***",
         cacheable: bool = True,
     ) -> None:
+        """
+        Args:
+            info: The info string to serve to the client.
+            cacheable: Whether raising this error should be recorded as a scan failure in
+                the scanner's result cache.
+        """
         super(FileDirtyError, self).__init__(
             http_status=403,
             reason=ErrCode.NOT_CLEAN,

--- a/matrix_content_scanner/utils/errors.py
+++ b/matrix_content_scanner/utils/errors.py
@@ -11,13 +11,15 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+from typing import Optional
+
 from matrix_content_scanner.utils.constants import ErrCode
 
 
 class ContentScannerRestError(Exception):
     """An error that is converted into an error response by the REST resource."""
 
-    def __init__(self, http_status: int, reason: ErrCode, info: str) -> None:
+    def __init__(self, http_status: int, reason: ErrCode, info: Optional[str]) -> None:
         super(Exception, self).__init__(info)
         self.http_status = http_status
         self.reason = reason
@@ -27,12 +29,18 @@ class ContentScannerRestError(Exception):
 class FileDirtyError(ContentScannerRestError):
     """An error indicating that the file being scanned is dirty."""
 
-    def __init__(self, info: str = "***VIRUS DETECTED***") -> None:
+    def __init__(
+        self,
+        info: Optional[str] = "***VIRUS DETECTED***",
+        cacheable: bool = True,
+    ) -> None:
         super(FileDirtyError, self).__init__(
             http_status=403,
             reason=ErrCode.NOT_CLEAN,
             info=info,
         )
+
+        self.cacheable = cacheable
 
 
 class ConfigError(Exception):

--- a/matrix_content_scanner/utils/types.py
+++ b/matrix_content_scanner/utils/types.py
@@ -24,6 +24,7 @@ class MediaDescription:
     content_type: str
     content: bytes
     response_headers: Headers
+    cacheable: bool = True
 
 
 # A JSON object/dictionary.

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,10 @@ install_requires =
   python-olm
   unpaddedbase64
   PyCryptodome
+  # Required for maintaining the result cache.
+  cachetools
+  # Required for processing user-defined values such as durations or sizes.
+  humanfriendly
 
 
 [options.extras_require]
@@ -37,6 +41,7 @@ dev =
   mypy-zope
   types-jsonschema
   types-PyYAML
+  types-cachetools
   # for linting
   black == 22.3.0
   flake8 == 4.0.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,9 @@ install_requires =
   cachetools
   # Required for processing user-defined values such as durations or sizes.
   humanfriendly
+  # Required for calculating cache keys deterministically. Type annotations aren't
+  # discoverable in versions older than 1.6.3.
+  canonicaljson >= 1.6.3
 
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,7 @@ dev =
   types-jsonschema
   types-PyYAML
   types-cachetools
+  types-humanfriendly
   # for linting
   black == 22.3.0
   flake8 == 4.0.1

--- a/tests/scanner/test_file_downloader.py
+++ b/tests/scanner/test_file_downloader.py
@@ -156,6 +156,7 @@ class FileDownloaderTestCase(aiounittest.AsyncTestCase):
             await self.downloader.download_file(MEDIA_PATH)
 
         self.assertEqual(cm.exception.http_status, 502)
+        assert cm.exception.info is not None
         self.assertTrue("Content-Type" in cm.exception.info)
 
     async def test_no_content_type(self) -> None:
@@ -168,6 +169,7 @@ class FileDownloaderTestCase(aiounittest.AsyncTestCase):
             await self.downloader.download_file(MEDIA_PATH)
 
         self.assertEqual(cm.exception.http_status, 502)
+        assert cm.exception.info is not None
         self.assertTrue("Content-Type" in cm.exception.info)
 
 

--- a/tests/scanner/test_scanner.py
+++ b/tests/scanner/test_scanner.py
@@ -127,6 +127,23 @@ class ScannerTestCase(aiounittest.AsyncTestCase):
         await self.scanner.scan_file(MEDIA_PATH, thumbnail_params={"height": ["50"]})
         self.assertEqual(self.downloader_mock.call_count, 2)
 
+    async def test_cache_max_size(self) -> None:
+        """Tests that we don't cache files if they exceed the configured maximum file
+        size.
+        """
+        # Set the maximum file size to be just under the size of the file.
+        self.scanner._max_size_to_cache = len(SMALL_PNG) - 1
+
+        # Scan the file a first time, and check that the downloader has been called.
+        await self.scanner.scan_file(MEDIA_PATH)
+        self.assertEqual(self.downloader_mock.call_count, 1)
+
+        # Scan the file a second time, and check that the downloader has been called
+        # again.
+        media = await self.scanner.scan_file(MEDIA_PATH)
+        self.assertEqual(self.downloader_mock.call_count, 2)
+        self.assertEqual(media.content, SMALL_PNG)
+
     async def test_different_encryption_key(self) -> None:
         """Tests that if some of the file's metadata changed, we don't match against the
         cache and we download the file again.

--- a/tests/scanner/test_scanner.py
+++ b/tests/scanner/test_scanner.py
@@ -13,11 +13,12 @@
 #  limitations under the License.
 import copy
 from typing import Dict, List, Optional
-from unittest.mock import Mock
+from unittest.mock import Mock, AsyncMock
 
 import aiounittest
 from twisted.web.http_headers import Headers
 
+from matrix_content_scanner.scanner.scanner import CacheEntry
 from matrix_content_scanner.utils.constants import ErrCode
 from matrix_content_scanner.utils.errors import ContentScannerRestError, FileDirtyError
 from matrix_content_scanner.utils.types import MediaDescription
@@ -143,6 +144,48 @@ class ScannerTestCase(aiounittest.AsyncTestCase):
         media = await self.scanner.scan_file(MEDIA_PATH)
         self.assertEqual(self.downloader_mock.call_count, 2)
         self.assertEqual(media.content, SMALL_PNG)
+
+    async def test_cache_max_size_mismatching_hash(self) -> None:
+        """Tests that we re-scan big files if the hash we have cached for them does not
+        match the hash of the newly downloaded content.
+        """
+        # Mock the _run_scan command so we can keep track of its call count.
+        mock_runner = Mock(return_value=0)
+        self.scanner._run_scan = mock_runner  # type: ignore[assignment]
+
+        # Calculate the cache key for this file so we can look it up later.
+        cache_key = self.scanner._get_cache_key_for_file(MEDIA_PATH, None, None)
+
+        # Set the maximum file size to be just under the size of the file.
+        self.scanner._max_size_to_cache = len(SMALL_PNG) - 1
+
+        # Make sure the cache is empty.
+        self.assertEqual(len(self.scanner._result_cache), 0)
+
+        # Scan the file a first time, and check that the file has been scanned.
+        await self.scanner.scan_file(MEDIA_PATH)
+        self.assertEqual(self.downloader_mock.call_count, 1)
+        mock_runner.assert_called_once()
+
+        # Test that the file has been cached.
+        self.assertIn(cache_key, self.scanner._result_cache)
+
+        # Change the hash of the cache entry to force it to be scanned again.
+        entry: CacheEntry = self.scanner._result_cache[cache_key]
+        self.scanner._result_cache[cache_key] = CacheEntry(
+            result=entry.result,
+            media=entry.media,
+            media_hash=b'BAD_HASH',
+            info=entry.info,
+        )
+
+        # Run the scanner again and check that the cache entry for the file has been
+        # discarded (i.e. the scan is run again).
+        await self.scanner.scan_file(MEDIA_PATH)
+        self.assertEqual(mock_runner.call_count, 2)
+
+        # Also check that the file has only been re-downloaded once.
+        self.assertEqual(self.downloader_mock.call_count, 2)
 
     async def test_different_encryption_key(self) -> None:
         """Tests that if some of the file's metadata changed, we don't match against the

--- a/tests/scanner/test_scanner.py
+++ b/tests/scanner/test_scanner.py
@@ -175,7 +175,7 @@ class ScannerTestCase(aiounittest.AsyncTestCase):
         self.scanner._result_cache[cache_key] = CacheEntry(
             result=entry.result,
             media=entry.media,
-            media_hash=b"BAD_HASH",
+            media_hash="BAD_HASH",
             info=entry.info,
         )
 

--- a/tests/scanner/test_scanner.py
+++ b/tests/scanner/test_scanner.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 import copy
 from typing import Dict, List, Optional
-from unittest.mock import Mock, AsyncMock
+from unittest.mock import Mock
 
 import aiounittest
 from twisted.web.http_headers import Headers
@@ -175,7 +175,7 @@ class ScannerTestCase(aiounittest.AsyncTestCase):
         self.scanner._result_cache[cache_key] = CacheEntry(
             result=entry.result,
             media=entry.media,
-            media_hash=b'BAD_HASH',
+            media_hash=b"BAD_HASH",
             info=entry.info,
         )
 


### PR DESCRIPTION
Builds on top of https://github.com/matrix-org/matrix-content-scanner-python/pull/17 to cache results and contents of files in a time-based LRU cache so we don't spend our time fetching media from the homeserver.

To somewhat prevent big files from blowing cache size beyond reason, I've also added a size limit beyond which file contents aren't cached (only the results). If a file isn't cached because it's over this limit and is requested again, we just download it again, without writing it to disk or scanning it again.