### PR TITLE
Check MIME types against config before scanning

### DIFF
--- a/matrix_content_scanner/scanner/scanner.py
+++ b/matrix_content_scanner/scanner/scanner.py
@@ -24,6 +24,7 @@ from canonicaljson import encode_canonical_json
 from humanfriendly import format_size
 from mautrix.crypto.attachments import decrypt_attachment
 from mautrix.errors import DecryptionError
+from mautrix.util import magic
 
 from matrix_content_scanner.utils.constants import ErrCode
 from matrix_content_scanner.utils.errors import ContentScannerRestError, FileDirtyError
@@ -77,6 +78,8 @@ class Scanner:
             self._exit_codes_to_ignore = mcs.config.result_cache.exit_codes_to_ignore
 
         self._max_size_to_cache = mcs.config.result_cache.max_file_size
+
+        self._allowed_mimetypes = mcs.config.scan.allowed_mimetypes
 
     async def scan_file(
         self,
@@ -250,6 +253,14 @@ class Scanner:
             # If the file is encrypted, we need to decrypt it before we can scan it.
             media_content = self._decrypt_file(media_content, metadata)
 
+        # Check the file's MIME type to see if it's allowed and, if the file is not
+        # encrypted, if it matches the Content-Type header the homeserver sent us.
+        self._check_mimetype(
+            media_content=media_content,
+            content_type_header=media.content_type,
+            encrypted=metadata is not None,
+        )
+
         # Write the file to disk.
         file_path = self._write_file_to_disk(media_path, media_content)
 
@@ -390,3 +401,51 @@ class Scanner:
         except subprocess.CalledProcessError as e:
             logger.info("Scan failed with exit code %d: %s", e.returncode, e.stderr)
             return e.returncode
+
+    def _check_mimetype(
+        self,
+        media_content: bytes,
+        content_type_header: str,
+        encrypted: bool,
+    ) -> None:
+        """Reads the MIME type of the provided bytes, and checks that:
+        * it matches with the Content-Type header that was received when downloading this
+            file (if the media isn't encrypted, since otherwise the Content-Type header
+            is always 'application/octet-stream')
+        * files with this MIME type are allowed (if an allow list is provided in the
+            configuration)
+        Args:
+            media_content: The file's content. If the file is encrypted, this is its
+                decrypted content.
+            content_type_header: The value of the Content-Type header received when
+                downloading the file.
+            encrypted: Whether the file was encrypted (in which case we don't want to
+                check that its MIME type matches with the Content-Type header).
+        Raises:
+            FileDirtyError if one of the checks fail.
+        """
+        mimetype = magic.mimetype(media_content)
+        logger.info("MIME type for file is %s", mimetype)
+
+        # Check if the MIME type is matching the one that's expected, but only if the file
+        # is not encrypted (because otherwise we'll always have 'application/octet-stream'
+        # in the Content-Type header regardless of the actual MIME type of the file).
+        if encrypted is False and mimetype != content_type_header:
+            logger.error(
+                "Mismatching MIME type (%s) and Content-Type header (%s)",
+                mimetype,
+                content_type_header,
+            )
+            raise FileDirtyError("File type not supported")
+
+        # If there's an allow list for MIME types, check that the MIME type that's been
+        # detected for this file is in it.
+        if (
+            self._allowed_mimetypes is not None
+            and mimetype not in self._allowed_mimetypes
+        ):
+            logger.error(
+                "MIME type for file is forbidden: %s",
+                mimetype,
+            )
+            raise FileDirtyError("File type not supported")

--- a/matrix_content_scanner/scanner/scanner.py
+++ b/matrix_content_scanner/scanner/scanner.py
@@ -79,6 +79,9 @@ class Scanner:
 
         self._max_size_to_cache = mcs.config.result_cache.max_file_size
 
+        # List of MIME types we should allow. If None, we don't fail files based on their
+        # MIME types (besides comparing it with the Content-Type header from the server
+        # for unencrypted files).
         self._allowed_mimetypes = mcs.config.scan.allowed_mimetypes
 
     async def scan_file(


### PR DESCRIPTION
When scanning a file, look up its MIME type, and checks that:

* if the file was not encrypted in the first place, it matches what the remote homeserver claims it is
* it's a MIME type that's allowed by the configuration (if any)