### PR TITLE
Add validation utils for encrypted file metadata

### DIFF
--- a/matrix_content_scanner/utils/encrypted_file_metadata.py
+++ b/matrix_content_scanner/utils/encrypted_file_metadata.py
@@ -39,12 +39,13 @@ _encrypted_file_metadata_schema = {
                 },
                 "key": {
                     "type": "object",
-                    "required": ["alg", "kty", "k", "key_ops"],
+                    "required": ["alg", "kty", "k", "key_ops", "ext"],
                     "properties": {
                         "alg": {"const": "A256CTR"},
                         "kty": {"const": "oct"},
                         "k": {"type": "string"},
                         "key_ops": {"type": "array", "items": {"type": "string"}},
+                        "ext": {"const": True},
                     },
                 },
             },

--- a/matrix_content_scanner/utils/encrypted_file_metadata.py
+++ b/matrix_content_scanner/utils/encrypted_file_metadata.py
@@ -1,0 +1,95 @@
+#  Copyright 2022 The Matrix.org Foundation C.I.C.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+from jsonschema import ValidationError, validate
+
+from matrix_content_scanner.utils.constants import ErrCode
+from matrix_content_scanner.utils.errors import ContentScannerRestError
+from matrix_content_scanner.utils.types import JsonDict
+
+# This is a subset of the content of an m.room.message event that includes a file, with
+# only the info that we need to locate and decrypt the file.
+_encrypted_file_metadata_schema = {
+    "type": "object",
+    "required": ["file"],
+    "properties": {
+        "file": {
+            "type": "object",
+            "required": ["v", "iv", "url", "hashes", "key"],
+            "properties": {
+                "v": {"const": "v2"},
+                "iv": {"type": "string"},
+                "url": {"type": "string"},
+                "hashes": {
+                    "type": "object",
+                    "required": ["sha256"],
+                    "properties": {
+                        "sha256": {"type": "string"},
+                    },
+                },
+                "key": {
+                    "type": "object",
+                    "required": ["alg", "kty", "k", "key_ops"],
+                    "properties": {
+                        "alg": {"const": "A256CTR"},
+                        "kty": {"const": "oct"},
+                        "k": {"type": "string"},
+                        "key_ops": {"type": "array", "items": {"type": "string"}},
+                    },
+                },
+            },
+        },
+    },
+}
+
+
+def _validate(body: JsonDict) -> None:
+    """Validates the schema using jsonschema, and by checking whether the `key_ops` list
+    includes at least `encrypt` and `decrypt`.
+
+    Args:
+        body: The body to validate.
+
+    Raises:
+        ValidationError if the jsonschema validation failed.
+        ValueError if the `key_ops` list doesn't include at least `encrypt` and `decrypt`.
+    """
+    validate(body, _encrypted_file_metadata_schema)
+
+    # We don't need to worry about triggering a KeyError/TypeError here because all of
+    # these keys are marked as required in the schema, so at this point we know they're
+    # here.
+    key_ops = body["file"]["key"]["key_ops"]
+    # We need the key_ops list to at least include "encrypt" and "decrypt", but we can't
+    # check this with jsonschema, so we need to do it manually.
+    if not set(key_ops).issuperset({"encrypt", "decrypt"}):
+        raise ValueError('key_ops must contain at least "encrypt" and "decrypt"')
+
+
+def validate_encrypted_file_metadata(body: JsonDict) -> None:
+    """Validates the schema of the given dictionary, and turns any validation error
+    raised into a client error.
+
+    Args:
+        body: The body to validate.
+
+    Raises:
+        ContentScannerRestError(400) if the validation failed.
+    """
+    # Run the validation and turns any error coming out of it into a REST error.
+    try:
+        _validate(body)
+    except ValidationError as e:
+        raise ContentScannerRestError(400, ErrCode.MALFORMED_JSON, e.message)
+    except ValueError as e:
+        raise ContentScannerRestError(400, ErrCode.MALFORMED_JSON, str(e))

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright 2022 The Matrix.org Foundation C.I.C.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/tests/utils/test_encrypted_file_metadata.py
+++ b/tests/utils/test_encrypted_file_metadata.py
@@ -1,0 +1,92 @@
+#  Copyright 2022 The Matrix.org Foundation C.I.C.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import copy
+import unittest
+
+from matrix_content_scanner.utils.constants import ErrCode
+from matrix_content_scanner.utils.encrypted_file_metadata import (
+    validate_encrypted_file_metadata,
+)
+from matrix_content_scanner.utils.errors import ContentScannerRestError
+from tests.testutils import ENCRYPTED_FILE_METADATA
+
+
+class EncryptedMetadataValidationTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.metadata = copy.deepcopy(ENCRYPTED_FILE_METADATA)
+
+    def test_validate(self) -> None:
+        """Tests that valid file metadata is considered as such."""
+        validate_encrypted_file_metadata(ENCRYPTED_FILE_METADATA)
+
+    def test_key_ops_no_decrypt(self) -> None:
+        """Tests that the metadata validation fails if key_ops doesn't include `decrypt`."""
+        self.metadata["file"]["key"]["key_ops"] = ["encrypt"]
+        self._test_fails_validation()
+
+    def test_key_ops_no_encrypt(self) -> None:
+        """Tests that the metadata validation fails if key_ops doesn't include `encrypt`."""
+        self.metadata["file"]["key"]["key_ops"] = ["decrypt"]
+        self._test_fails_validation()
+
+    def test_no_file(self) -> None:
+        """Tests that the metadata validation fails if there isn't a `file` property."""
+        self.metadata = {"foo": "bar"}
+        self._test_fails_validation()
+
+    def test_no_key(self) -> None:
+        """Tests that the metadata validation fails if there isn't a `file.key` property."""
+        del self.metadata["file"]["key"]
+        self._test_fails_validation()
+
+    def test_no_k(self) -> None:
+        """Tests that the metadata validation fails if there isn't a `file.key.k`
+        property.
+        """
+        del self.metadata["file"]["key"]["k"]
+        self._test_fails_validation()
+
+    def test_no_iv(self) -> None:
+        """Tests that the metadata validation fails if there isn't a `file.iv` property."""
+        del self.metadata["file"]["iv"]
+        self._test_fails_validation()
+
+    def test_no_url(self) -> None:
+        """Tests that the metadata validation fails if there isn't a `file.url` property."""
+        del self.metadata["file"]["url"]
+        self._test_fails_validation()
+
+    def test_no_hashes(self) -> None:
+        """Tests that the metadata validation fails if there isn't a `file.hashes`
+        property.
+        """
+        del self.metadata["file"]["hashes"]
+        self._test_fails_validation()
+
+    def test_no_sha256(self) -> None:
+        """Tests that the metadata validation fails if there isn't a `file.hashes.sha256`
+        property.
+        """
+        del self.metadata["file"]["hashes"]["sha256"]
+        self._test_fails_validation()
+
+    def _test_fails_validation(self) -> None:
+        """Tests that the validation fails with a REST error complaining about malformed
+        JSON.
+        """
+        with self.assertRaises(ContentScannerRestError) as cm:
+            validate_encrypted_file_metadata(self.metadata)
+
+        self.assertEqual(cm.exception.http_status, 400)
+        self.assertEqual(cm.exception.reason, ErrCode.MALFORMED_JSON)

--- a/tests/utils/test_encrypted_file_metadata.py
+++ b/tests/utils/test_encrypted_file_metadata.py
@@ -57,6 +57,20 @@ class EncryptedMetadataValidationTestCase(unittest.TestCase):
         del self.metadata["file"]["key"]["k"]
         self._test_fails_validation()
 
+    def test_no_ext(self) -> None:
+        """Tests that the metadata validation fails if there isn't a `file.key.ext`
+        property.
+        """
+        del self.metadata["file"]["key"]["ext"]
+        self._test_fails_validation()
+
+    def test_ext_not_true(self) -> None:
+        """Tests that the metadata validation fails if the `file.key.ext` property has an
+        invalid value.
+        """
+        self.metadata["file"]["key"]["ext"] = False
+        self._test_fails_validation()
+
     def test_no_iv(self) -> None:
         """Tests that the metadata validation fails if there isn't a `file.iv` property."""
         del self.metadata["file"]["iv"]

--- a/tests/utils/test_encrypted_file_metadata.py
+++ b/tests/utils/test_encrypted_file_metadata.py
@@ -40,6 +40,13 @@ class EncryptedMetadataValidationTestCase(unittest.TestCase):
         self.metadata["file"]["key"]["key_ops"] = ["decrypt"]
         self._test_fails_validation()
 
+    def test_ops_extra_values(self) -> None:
+        """tests that the metadata validation does not fail if there are extra values in
+        key_ops.
+        """
+        self.metadata["file"]["key"]["key_ops"].append("foo")
+        validate_encrypted_file_metadata(self.metadata)
+
     def test_no_file(self) -> None:
         """Tests that the metadata validation fails if there isn't a `file` property."""
         self.metadata = {"foo": "bar"}
@@ -64,11 +71,25 @@ class EncryptedMetadataValidationTestCase(unittest.TestCase):
         del self.metadata["file"]["key"]["ext"]
         self._test_fails_validation()
 
-    def test_ext_not_true(self) -> None:
+    def test_bad_ext(self) -> None:
         """Tests that the metadata validation fails if the `file.key.ext` property has an
         invalid value.
         """
         self.metadata["file"]["key"]["ext"] = False
+        self._test_fails_validation()
+
+    def test_bad_alg(self) -> None:
+        """Tests that the metadata validation fails if the `file.key.alg` property has an
+        invalid value.
+        """
+        self.metadata["file"]["key"]["alg"] = "bad"
+        self._test_fails_validation()
+
+    def test_bad_kty(self) -> None:
+        """Tests that the metadata validation fails if the `file.key.kty` property has an
+        invalid value.
+        """
+        self.metadata["file"]["key"]["kty"] = "bad"
         self._test_fails_validation()
 
     def test_no_iv(self) -> None:


### PR DESCRIPTION
When scanning an encrypted file, clients are expected to send the content scanner some metadata it can use to decrypt it. This is typically the `file` property of the `m.room.message` event content. See https://github.com/matrix-org/matrix-content-scanner-python/blob/main/docs/api.md#post-_matrixmedia_proxyunstabledownload_encrypted to see how it fits into the API, and an example.

This adds a `validate_encrypted_file_metadata` util that performs a few validation checks on the client-provided data to ensure it's in the right format before passing it on to the scanner. This will then be used by the http handler code (coming in a future PR, see https://github.com/matrix-org/matrix-content-scanner-python-wip/blob/main/matrix_content_scanner/servlets/__init__.py#L166-L241 to see what it will looks like).

Closes #7 