### PR TITLE
Add a crypto handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,23 +24,13 @@ pip install matrix-content-scanner
 Copy and edit the [sample configuration file](https://github.com/matrix-org/matrix-content-scanner-python/blob/main/config.sample.yaml).
 Each key is documented in this file.
 
-Before running the Matrix Content Scanner for the first time (if you are not [migrating
-from the legacy Matrix Content Scanner](#migrating-from-the-legacy-matrix-content-scanner)),
-run (from within your virtual environment if one was created):
-
-```commandline
-python -m matrix_content_scanner.mcs -c CONFIG_FILE --generate-secrets
-```
-
-Where `CONFIG_FILE` is the path to your configuration file.
-
-This will generate the cryptographic secrets required for the content scanner to run.
-
-Then run the content scanner:
+Then run the content scanner (from within your virtual environment if one was created):
 
 ```commandline
 python -m matrix_content_scanner.mcs -c CONFIG_FILE
 ```
+
+Where `CONFIG_FILE` is the path to your configuration file.
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ deployment instructions) is the configuration format:
 * `acceptedMimeType` is renamed `scan.allowed_mimetypes`
 * `requestHeader` is renamed `download.additional_headers` and turned into a dictionary.
 
-Note that the format of the cryptographic pickle file file and key are compatible between
+Note that the format of the cryptographic pickle file and key are compatible between
 this project and the legacy Matrix Content Scanner. If no file exist at that path one will
 be created automatically.
 

--- a/README.md
+++ b/README.md
@@ -24,13 +24,23 @@ pip install matrix-content-scanner
 Copy and edit the [sample configuration file](https://github.com/matrix-org/matrix-content-scanner-python/blob/main/config.sample.yaml).
 Each key is documented in this file.
 
-Then run the content scanner (from within your virtual environment if one was created):
+Before running the Matrix Content Scanner for the first time (if you are not [migrating
+from the legacy Matrix Content Scanner](#migrating-from-the-legacy-matrix-content-scanner)),
+run (from within your virtual environment if one was created):
+
+```commandline
+python -m matrix_content_scanner.mcs -c CONFIG_FILE --generate-secrets
+```
+
+Where `CONFIG_FILE` is the path to your configuration file.
+
+This will generate the cryptographic secrets required for the content scanner to run.
+
+Then run the content scanner:
 
 ```commandline
 python -m matrix_content_scanner.mcs -c CONFIG_FILE
 ```
-
-Where `CONFIG_FILE` is the path to your configuration file.
 
 ## API
 
@@ -56,9 +66,9 @@ deployment instructions) is the configuration format:
 * `acceptedMimeType` is renamed `scan.allowed_mimetypes`
 * `requestHeader` is renamed `download.additional_headers` and turned into a dictionary.
 
-Note that the format of the cryptographic pickle file and key are compatible between this
-project and the legacy Matrix Content Scanner. If no file exist at that path one will be
-created automatically.
+Note that the format of the cryptographic pickle file file and key are compatible between
+this project and the legacy Matrix Content Scanner. If no file exist at that path one will
+be created automatically.
 
 ## Development
 

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -102,7 +102,7 @@ download:
 crypto:
     # The path to the Olm pickle file. This file contains the key pair to use when
     # encrypting and decrypting encrypted POST request bodies.
-    # The pickle file is automatically created at startup if it doesn't already exist.
+    # A new keypair will be created at startup if the pickle file doesn't already exist.
     # Required.
     pickle_path: "./pickle"
 

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -100,10 +100,13 @@ download:
 
 # Configuration for decrypting Olm-encrypted request bodies.
 crypto:
-    # The path to the Olm pickle file.
+    # The path to the Olm pickle file. This file contains the key pair to use when
+    # encrypting and decrypting encrypted POST request bodies.
+    # This file needs to be created with the --generate-secrets command line argument
+    # for the Matrix Content Scanner to run, see README.md for more information.
     # Required.
     pickle_path: "./pickle"
 
-    # The key to the pickle.
+    # The key to use to decode the pickle file.
     # Required.
     pickle_key: "this_is_a_secret"

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -102,8 +102,6 @@ download:
 crypto:
     # The path to the Olm pickle file. This file contains the key pair to use when
     # encrypting and decrypting encrypted POST request bodies.
-    # This file needs to be created with the --generate-secrets command line argument
-    # for the Matrix Content Scanner to run, see README.md for more information.
     # Required.
     pickle_path: "./pickle"
 

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -102,6 +102,7 @@ download:
 crypto:
     # The path to the Olm pickle file. This file contains the key pair to use when
     # encrypting and decrypting encrypted POST request bodies.
+    # The pickle file is automatically created at startup if it doesn't already exist.
     # Required.
     pickle_path: "./pickle"
 

--- a/matrix_content_scanner/config.py
+++ b/matrix_content_scanner/config.py
@@ -62,29 +62,6 @@ def _parse_size(size: Optional[Union[str, float]]) -> Optional[float]:
         raise ConfigError(e)
 
 
-def _check_file_path(raw_path: str) -> None:
-    """Check if the file at the given path exists and is readable. If it's not, check if
-    the parent directory exists and is writeable.
-
-    Args:
-        raw_path: The path to check.
-
-    Raises:
-        ConfigError if the file does not exist and the parent directory cannot be written
-            into or does not exist.
-    """
-    path = Path(raw_path).resolve()
-
-    if os.access(path, os.R_OK):
-        return
-
-    if not os.access(path.parent, os.W_OK):
-        raise ConfigError(
-            "File %s does not exist and parent directory is not writeable or does not exist"
-            % raw_path
-        )
-
-
 # Schema to validate the raw configuration dictionary against.
 _config_schema = {
     "type": "object",
@@ -206,6 +183,3 @@ class MatrixContentScannerConfig:
         self.crypto = CryptoConfig(**(config_dict.get("crypto") or {}))
         self.download = DownloadConfig(**(config_dict.get("download") or {}))
         self.result_cache = ResultCacheConfig(**(config_dict.get("result_cache") or {}))
-
-        # Check that we can read the pickle file, or create it if it doesn't exist.
-        _check_file_path(self.crypto.pickle_path)

--- a/matrix_content_scanner/config.py
+++ b/matrix_content_scanner/config.py
@@ -11,8 +11,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-import os
-from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 import attr

--- a/matrix_content_scanner/crypto.py
+++ b/matrix_content_scanner/crypto.py
@@ -52,18 +52,12 @@ class CryptoHandler:
                 # content.
                 raise ConfigError(
                     "Configured value for crypto.pickle_key is incorrect or pickle file"
-                    " is corrupted (Olm error code: %s)" % e
+                    f" is corrupted (Olm error code: {e})"
                 )
 
             logger.info("Loaded Olm key pair from pickle file %s", path)
 
-        except OSError as e:
-            if not isinstance(e, FileNotFoundError):
-                raise ConfigError(
-                    "Failed to read the pickle file at the location configured for"
-                    " crypto.pickle_path (%s): %s" % (path, e)
-                )
-
+        except FileNotFoundError:
             logger.info(
                 "Pickle file not found, generating a new Olm key pair and storing it in"
                 " pickle file %s",
@@ -81,8 +75,14 @@ class CryptoHandler:
             except OSError as e:
                 raise ConfigError(
                     "Failed to write the pickle file at the location configured for"
-                    " crypto.pickle_path (%s): %s" % (path, e)
+                    f" crypto.pickle_path ({path}): {e}"
                 )
+
+        except OSError as e:
+            raise ConfigError(
+                "Failed to read the pickle file at the location configured for"
+                f" crypto.pickle_path ({path}): {e}"
+            )
 
         self.public_key = self._decryptor.public_key
 

--- a/matrix_content_scanner/crypto.py
+++ b/matrix_content_scanner/crypto.py
@@ -19,7 +19,7 @@ from olm.pk import PkDecryption, PkDecryptionError, PkMessage
 
 from matrix_content_scanner.config import MatrixContentScannerConfig
 from matrix_content_scanner.utils.constants import ErrCode
-from matrix_content_scanner.utils.errors import ContentScannerRestError, ConfigError
+from matrix_content_scanner.utils.errors import ConfigError, ContentScannerRestError
 from matrix_content_scanner.utils.types import JsonDict
 
 if TYPE_CHECKING:

--- a/matrix_content_scanner/crypto.py
+++ b/matrix_content_scanner/crypto.py
@@ -1,0 +1,91 @@
+#  Copyright 2022 The Matrix.org Foundation C.I.C.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import json
+import logging
+from typing import TYPE_CHECKING
+
+from olm.pk import PkDecryption, PkDecryptionError, PkMessage
+
+from matrix_content_scanner.utils.constants import ErrCode
+from matrix_content_scanner.utils.errors import ContentScannerRestError
+from matrix_content_scanner.utils.types import JsonDict
+
+if TYPE_CHECKING:
+    from matrix_content_scanner.mcs import MatrixContentScanner
+
+
+logger = logging.getLogger(__name__)
+
+
+class CryptoHandler:
+    """Handler for handling Olm-encrypted request bodies."""
+
+    def __init__(self, mcs: "MatrixContentScanner") -> None:
+        key = mcs.config.crypto.pickle_key
+        path = mcs.config.crypto.pickle_path
+        try:
+            # Try reading the pickle from disk.
+            with open(path, "r") as fp:
+                pickle = fp.read()
+
+            # Create a PkDecryption object with the content and key.
+            self._decryptor: PkDecryption = PkDecryption.from_pickle(
+                pickle=pickle.encode("ascii"),
+                passphrase=key,
+            )
+
+            logger.info("Loaded Olm pickle from %s", path)
+        except FileNotFoundError:
+            # If the pickle file doesn't exist, try creating it.
+            self._decryptor = PkDecryption()
+            pickle_bytes = self._decryptor.pickle(passphrase=key)
+
+            logger.info(
+                "Olm pickle not found, generating one and saving it at %s", path
+            )
+
+            with open(path, "w+") as fp:
+                fp.write(pickle_bytes.decode("ascii"))
+
+        self.public_key = self._decryptor.public_key
+
+    def decrypt_body(self, ciphertext: str, mac: str, ephemeral: str) -> JsonDict:
+        """Decrypts an Olm-encrypted body.
+
+        Args:
+            ciphertext: The encrypted body's ciphertext.
+            mac: The encrypted body's MAC.
+            ephemeral: The encrypted body's ephemeral key.
+
+        Returns:
+            The decrypted body, parsed as JSON.
+        """
+        try:
+            decrypted = self._decryptor.decrypt(
+                message=PkMessage(
+                    ephemeral_key=ephemeral,
+                    mac=mac,
+                    ciphertext=ciphertext,
+                )
+            )
+        except PkDecryptionError as e:
+            logger.error("Failed to decrypt encrypted body: %s", e)
+            raise ContentScannerRestError(
+                http_status=400,
+                reason=ErrCode.FAILED_TO_DECRYPT,
+                info=str(e),
+            )
+
+        # We know that `decrypted` parses as a JsonDict.
+        return json.loads(decrypted)  # type: ignore[no-any-return]

--- a/matrix_content_scanner/crypto.py
+++ b/matrix_content_scanner/crypto.py
@@ -48,12 +48,12 @@ class CryptoHandler:
             logger.info("Loaded Olm pickle from %s", path)
         except FileNotFoundError:
             # If the pickle file doesn't exist, try creating it.
-            self._decryptor = PkDecryption()
-            pickle_bytes = self._decryptor.pickle(passphrase=key)
-
             logger.info(
                 "Olm pickle not found, generating one and saving it at %s", path
             )
+
+            self._decryptor = PkDecryption()
+            pickle_bytes = self._decryptor.pickle(passphrase=key)
 
             with open(path, "w+") as fp:
                 fp.write(pickle_bytes.decode("ascii"))

--- a/matrix_content_scanner/mcs.py
+++ b/matrix_content_scanner/mcs.py
@@ -24,6 +24,7 @@ from yaml.scanner import ScannerError
 
 from matrix_content_scanner import logutils
 from matrix_content_scanner.config import MatrixContentScannerConfig
+from matrix_content_scanner.crypto import CryptoHandler
 from matrix_content_scanner.httpserver import HTTPServer
 from matrix_content_scanner.scanner.file_downloader import FileDownloader
 from matrix_content_scanner.scanner.scanner import Scanner
@@ -57,6 +58,10 @@ class MatrixContentScanner:
     @cached_property
     def scanner(self) -> Scanner:
         return Scanner(self)
+
+    @cached_property
+    def crypto_handler(self) -> CryptoHandler:
+        return CryptoHandler(self)
 
     def start(self) -> None:
         """Start the HTTP server and start the reactor."""

--- a/matrix_content_scanner/mcs.py
+++ b/matrix_content_scanner/mcs.py
@@ -105,7 +105,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--generate-secrets",
-        action='store_true',
+        action="store_true",
         help="Generate secrets such as cryptographic key pairs needed for the content scanner to run.",
     )
 

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1,0 +1,43 @@
+#  Copyright 2022 The Matrix.org Foundation C.I.C.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import json
+import unittest
+
+from olm.pk import PkEncryption
+
+from tests.testutils import get_content_scanner
+
+
+class CryptoHandlerTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.crypto_handler = get_content_scanner().crypto_handler
+
+    def test_decrypt(self) -> None:
+        """Tests that an Olm-encrypted payload is successfully decrypted."""
+        payload = {"foo": "bar"}
+
+        # Encrypt the payload with PkEncryption.
+        pke = PkEncryption(self.crypto_handler.public_key)
+        encrypted = pke.encrypt(json.dumps(payload))
+
+        # Decrypt the payload with the crypto handler.
+        decrypted = self.crypto_handler.decrypt_body(
+            encrypted.ciphertext,
+            encrypted.mac,
+            encrypted.ephemeral_key,
+        )
+
+        # Check that the decrypted payload is the same as the original one before
+        # encryption.
+        self.assertEqual(decrypted, payload)

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -18,7 +18,6 @@ from typing import Optional
 from twisted.web.http_headers import Headers
 
 from matrix_content_scanner.config import MatrixContentScannerConfig
-from matrix_content_scanner.crypto import CryptoHandler
 from matrix_content_scanner.mcs import MatrixContentScanner
 from matrix_content_scanner.utils.types import JsonDict
 
@@ -125,8 +124,5 @@ def get_content_scanner(config: Optional[JsonDict] = None) -> MatrixContentScann
     default_config.update(config)
 
     parsed_config = MatrixContentScannerConfig(default_config)
-
-    # Generate the Olm key pair and store them in a pickle file.
-    CryptoHandler.generate_and_store_key_pair(parsed_config)
 
     return MatrixContentScanner(parsed_config)

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -18,6 +18,7 @@ from typing import Optional
 from twisted.web.http_headers import Headers
 
 from matrix_content_scanner.config import MatrixContentScannerConfig
+from matrix_content_scanner.crypto import CryptoHandler
 from matrix_content_scanner.mcs import MatrixContentScanner
 from matrix_content_scanner.utils.types import JsonDict
 
@@ -123,4 +124,9 @@ def get_content_scanner(config: Optional[JsonDict] = None) -> MatrixContentScann
     # all required settings in that section.
     default_config.update(config)
 
-    return MatrixContentScanner(MatrixContentScannerConfig(default_config))
+    parsed_config = MatrixContentScannerConfig(default_config)
+
+    # Generate the Olm key pair and store them in a pickle file.
+    CryptoHandler.generate_and_store_key_pair(parsed_config)
+
+    return MatrixContentScanner(parsed_config)

--- a/tox.ini
+++ b/tox.ini
@@ -34,12 +34,12 @@ commands =
 extras = dev
 
 # The current version of python-olm that's on PyPI does not include a types marker.
-# Ideally we'd just specify a custom pip install command that uses an --index-url that
-# points to Olm's PyPI repo, but it looks like the packaging does not include py.typed in
-# wheels. https://gitlab.matrix.org/matrix-org/olm/-/merge_requests/62 is an attempt at
-# fixing this.
-deps =
-  git+https://gitlab.matrix.org/babolivier/olm.git@babolivier/py.typed_manifest#egg=python-olm&subdirectory=python
+# Hopefully that's something we can fix at some point, but in the mean time let's not
+# block things on this and instead use the wheels on gitlab.matrix.org's repository (which
+# do have a type marker). We use --index-url (and not --extra-index-url) so that pip does
+# not try to download the python-olm that's on pypi.org. This is fine because GitLab will
+# redirect requests for packages it doesn't know about to pypi.org.
+install_command = python -m pip install --index-url=https://gitlab.matrix.org/api/v4/projects/27/packages/pypi/simple {opts} {packages}
 
 commands =
   mypy matrix_content_scanner tests

--- a/tox.ini
+++ b/tox.ini
@@ -33,5 +33,13 @@ commands =
 
 extras = dev
 
+# The current version of python-olm that's on PyPI does not include a types marker.
+# Ideally we'd just specify a custom pip install command that uses an --index-url that
+# points to Olm's PyPI repo, but it looks like the packaging does not include py.typed in
+# wheels. https://gitlab.matrix.org/matrix-org/olm/-/merge_requests/62 is an attempt at
+# fixing this.
+deps =
+  git+https://gitlab.matrix.org/babolivier/olm.git@babolivier/py.typed_manifest#egg=python-olm&subdirectory=python
+
 commands =
   mypy matrix_content_scanner tests


### PR DESCRIPTION
To handle requests with an Olm-encrypted body, see https://github.com/matrix-org/matrix-content-scanner-python/blob/main/docs/api.md#encrypted-post-body

~Mypy checks are currently failing, I'm trying to work that out at https://gitlab.matrix.org/matrix-org/olm/-/merge_requests/62~ fixed now

The PyPI version of `python-olm` is too out of date to have type annotations (and the type marker), and updating it is currently blocked behind https://github.com/vector-im/legal-compliance/issues/223 and friends (which is at least a month away from being resolved).