### PR TITLE
Correctly print out error code in responses

### DIFF
--- a/matrix_content_scanner/servlets/__init__.py
+++ b/matrix_content_scanner/servlets/__init__.py
@@ -111,7 +111,7 @@ class _AsyncResource(Resource, metaclass=abc.ABCMeta):
 
         # Write the reason for the error into the response body, and add some extra info
         # if we have any.
-        res_body = {"reason": reason}
+        res_body: JsonDict = {"reason": reason}
         if info is not None:
             res_body["info"] = info
 

--- a/matrix_content_scanner/servlets/__init__.py
+++ b/matrix_content_scanner/servlets/__init__.py
@@ -111,7 +111,7 @@ class _AsyncResource(Resource, metaclass=abc.ABCMeta):
 
         # Write the reason for the error into the response body, and add some extra info
         # if we have any.
-        res_body = {"reason": str(reason)}
+        res_body = {"reason": reason}
         if info is not None:
             res_body["info"] = info
 


### PR DESCRIPTION
`str(code)` causes the value used in error responses to be a stringified version of the enum item's name:

```json
{
    "reason": "ErrCode.REQUEST_FAILED",
    "info": "Failed to reach the remote server"
}
```

After this change:

```json
{
    "reason": "MCS_MEDIA_REQUEST_FAILED",
    "info": "Failed to reach the remote server"
}
```